### PR TITLE
Remove scan of dongle for paired sensors

### DIFF
--- a/custom_components/wyzesense/binary_sensor.py
+++ b/custom_components/wyzesense/binary_sensor.py
@@ -7,6 +7,10 @@ wyzesense integration
 from .wyzesense_custom import *
 import logging
 import voluptuous as vol
+import json
+import os.path
+
+from os import path
 from retry import retry
 
 from homeassistant.const import CONF_FILENAME, CONF_DEVICE, \
@@ -71,6 +75,8 @@ def setup_platform(hass, config, add_entites, discovery_info=None):
                 new_entity = WyzeSensor(data)
                 entities[event.MAC] = new_entity
                 add_entites([new_entity])
+                f = open('.storage/wyze_sensors.txt', 'a')
+                f.write(event.MAC)
             else:
                 entities[event.MAC]._data = data
                 entities[event.MAC].schedule_update_ha_state()
@@ -81,9 +87,17 @@ def setup_platform(hass, config, add_entites, discovery_info=None):
 
     ws = beginConn()
 
+    result = []
+
     # Get bound sensors
-    result = ws.List()
-    _LOGGER.debug("%d Sensors Paired" % len(result))
+##    result = ws.List()
+## Loading sensors from json instead of getting from dongle
+    if path.exists('.storage/wyze_sensors.txt'):
+        sensor_file = open('.storage/wyze_sensors.txt')
+        result = sensor_file.readlines()
+        sensor_file.close()
+
+    _LOGGER.debug("%d Sensors Loaded from config" % len(result))
 
     for mac in result:
         _LOGGER.debug("Registering Sensor Entity: %s" % mac)

--- a/custom_components/wyzesense/binary_sensor.py
+++ b/custom_components/wyzesense/binary_sensor.py
@@ -89,9 +89,6 @@ def setup_platform(hass, config, add_entites, discovery_info=None):
 
     result = []
 
-    # Get bound sensors
-##    result = ws.List()
-## Loading sensors from json instead of getting from dongle
     if path.exists('.storage/wyze_sensors.txt'):
         sensor_file = open('.storage/wyze_sensors.txt')
         result = sensor_file.readlines()
@@ -101,6 +98,12 @@ def setup_platform(hass, config, add_entites, discovery_info=None):
 
     for mac in result:
         _LOGGER.debug("Registering Sensor Entity: %s" % mac)
+
+        mac = mac.strip()
+
+        if not len(mac) == 8:
+            _LOGGER.debug("Ignoring %s, Invalid length for MAC" % mac)
+            continue
 
         initial_state = forced_initial_states.get(mac)
 

--- a/custom_components/wyzesense/binary_sensor.py
+++ b/custom_components/wyzesense/binary_sensor.py
@@ -76,7 +76,7 @@ def setup_platform(hass, config, add_entites, discovery_info=None):
                 entities[event.MAC] = new_entity
                 add_entites([new_entity])
                 f = open('.storage/wyze_sensors.txt', 'a')
-                f.write(event.MAC)
+                f.write(event.MAC + "\r\n")
             else:
                 entities[event.MAC]._data = data
                 entities[event.MAC].schedule_update_ha_state()


### PR DESCRIPTION
Stores the sensors in a local file instead of relying on the dongle to return paired sensors. Resolved 
Fixes #29 