### PR TITLE
Add option to invert states

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ binary_sensor:
 ```
 By default, the component will restore the last state of the entity prior to a restart. If sensors change state during a restart, the change may not be reflected in HA. In order to combat this you can optionally specify an initial_state for sensors (by mac address) that will be set upon a restart. Be sure to put quotes around "on" or "off" so that they are strings not booleans.
 
-The invert_state option will allow you to swap the on/off state that is reported back to Home Assistant.  This could be useful for people that are not using the sensors in a traditional sense.  An example of such use case might include a momentary button wired into a contact sensor, or placing one inside a door bell chime to be triggers when rung.
+The invert_state option will allow you to swap the on/off state that is reported back to Home Assistant.  This could be useful for people that are not using the sensors in a traditional sense.  An example of such use case might include a momentary button wired into a contact sensor, or placing one inside a door bell chime to be triggered when rung.
 
 ## Usage
 * Restart HA and the sensors you have already bound to the hub (using the wyze app for example) will show up in your entities as `off` with `assumed_state: true` and no `device_class`. These will update and other attributes will be added once the component hears from the sensor for the first time.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ Are you a visual person? Here's a [video walkthrough](https://www.youtube.com/wa
 Add the following to your configuration file
 
 ```yaml
+- platform: wyzesense
+  device: auto
+```
+
+The custom_component will use the contents of `/sys/class/hidraw` to determine which `hidraw` device is the Wyze receiver dongle and then use that info to initialize the dongle.
+
+You can also optionally specify the hidraw device to use:
+
+```yaml
 binary_sensor:
   - platform: wyzesense
     device: "/dev/hidraw0"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Are you a visual person? Here's a [video walkthrough](https://www.youtube.com/watch?v=19UCwf4uidQ) of the setup and configuration. Check this README for the most up to date information.
 
+WARNING: This component does not work on Mac OSX systems.
+
 ## Installation (HACS) - Highly Recommended
 0. Have [HACS](https://github.com/custom-components/hacs) installed, this will allow you to easily update
 1. Add `https://github.com/kevinvincent/ha-wyzesense` as a [custom repository](https://custom-components.github.io/hacs/usage/settings/#add-custom-repositories) as Type: Integration

--- a/README.md
+++ b/README.md
@@ -46,8 +46,12 @@ binary_sensor:
     initial_state:
       77793176: "on"
       77793193: "off"
+    invert_state:
+      - 77793193
 ```
 By default, the component will restore the last state of the entity prior to a restart. If sensors change state during a restart, the change may not be reflected in HA. In order to combat this you can optionally specify an initial_state for sensors (by mac address) that will be set upon a restart. Be sure to put quotes around "on" or "off" so that they are strings not booleans.
+
+The invert_state option will allow you to swap the on/off state that is reported back to Home Assistant.  This could be useful for people that are not using the sensors in a traditional sense.  An example of such use case might include a momentary button wired into a contact sensor, or placing one inside a door bell chime to be triggers when rung.
 
 ## Usage
 * Restart HA and the sensors you have already bound to the hub (using the wyze app for example) will show up in your entities as `off` with `assumed_state: true` and no `device_class`. These will update and other attributes will be added once the component hears from the sensor for the first time.

--- a/custom_components/wyzesense/binary_sensor.py
+++ b/custom_components/wyzesense/binary_sensor.py
@@ -55,9 +55,8 @@ def findDongle():
                     return "/dev/%s" % w
 
 def setup_platform(hass, config, add_entites, discovery_info=None):
-    if config[CONF_DEVICE].lower() == 'auto': 
-        config[CONF_DEVICE] = findDongle()
-    _LOGGER.debug("WYZESENSE v0.0.4")
+
+    _LOGGER.debug("WYZESENSE v0.0.5")
     _LOGGER.debug("Attempting to open connection to hub at " + config[CONF_DEVICE])
 
     forced_initial_states = config[CONF_INITIAL_STATE]

--- a/custom_components/wyzesense/binary_sensor.py
+++ b/custom_components/wyzesense/binary_sensor.py
@@ -220,6 +220,4 @@ class WyzeSensor(BinarySensorDevice, RestoreEntity):
         del attributes[ATTR_STATE]
         del attributes[ATTR_AVAILABLE]
 
-        return attributes
-    
-
+        return attributes      

--- a/custom_components/wyzesense/binary_sensor.py
+++ b/custom_components/wyzesense/binary_sensor.py
@@ -31,7 +31,7 @@ CONF_INVERT_STATE = "invert_state"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_DEVICE, default = "auto"): cv.string, 
-    vol.Optional(CONF_INITIAL_STATE, default={}): vol.Schema({cv.string : vol.In(["on","off"]),
+    vol.Optional(CONF_INITIAL_STATE, default={}): vol.Schema({cv.string : vol.In(["on","off"])}),
     vol.Optional(CONF_INVERT_STATE, default=[]): vol.All(cv.ensure_list, [cv.string]),
 })
 


### PR DESCRIPTION
This adds the ability to invert the state of the sensors.  I have one stuck in my door bell and it is annoying seeing it as "open".  I know if could be changed via templates in the UI, but I think more and more people are going to be using these cheap sensors for unusual tasks to where the feature could be useful and its relatively simple.  