### PR TITLE
Add invert_state config option to reverse on/off state reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Forked and maintained copy of kevinvincent/ha-wyzesense
+
 # Home Assistant - WYZE Sense Component
 
 > Special thanks to [HcLX](https://hclxing.wordpress.com) and his work on [WyzeSensePy](https://github.com/HclX/WyzeSensePy) which is the core of this component. His reverse engineering talents and development of WyzeSensePy made it quite easy to connect with WYZE sense devices.

--- a/README.md
+++ b/README.md
@@ -46,8 +46,12 @@ binary_sensor:
     initial_state:
       77793176: "on"
       77793193: "off"
+	invert_state:
+      - 77793193
 ```
 By default, the component will restore the last state of the entity prior to a restart. If sensors change state during a restart, the change may not be reflected in HA. In order to combat this you can optionally specify an initial_state for sensors (by mac address) that will be set upon a restart. Be sure to put quotes around "on" or "off" so that they are strings not booleans.
+
+The invert_state option will allow you to swap the on/off state that is reported back to Home Assistant.  This could be useful for people that are not using the sensors in a traditional sense.  An example of such use case might include a momentary button wired into a contact sensor, or placing one inside a door bell chime to be triggered when rung.
 
 ## Usage
 * Restart HA and the sensors you have already bound to the hub (using the wyze app for example) will show up in your entities as `off` with `assumed_state: true` and no `device_class`. These will update and other attributes will be added once the component hears from the sensor for the first time.

--- a/custom_components/wyzesense/binary_sensor.py
+++ b/custom_components/wyzesense/binary_sensor.py
@@ -27,10 +27,12 @@ ATTR_MAC = "mac"
 ATTR_RSSI = "rssi"
 ATTR_AVAILABLE = "available"
 CONF_INITIAL_STATE = "initial_state"
+CONF_INVERT_STATE = "invert_state"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_DEVICE, default = "auto"): cv.string, 
-    vol.Optional(CONF_INITIAL_STATE, default={}): vol.Schema({cv.string : vol.In(["on","off"])})
+    vol.Optional(CONF_INITIAL_STATE, default={}): vol.Schema({cv.string : vol.In(["on","off"])}),
+    vol.Optional(CONF_INVERT_STATE, default=[]): vol.All(cv.ensure_list, [cv.string]),
 })
 
 SERVICE_SCAN = 'scan'
@@ -59,6 +61,8 @@ def setup_platform(hass, config, add_entites, discovery_info=None):
     _LOGGER.debug("Attempting to open connection to hub at " + config[CONF_DEVICE])
 
     forced_initial_states = config[CONF_INITIAL_STATE]
+    invert_states = config[CONF_INVERT_STATE]
+
     entities = {}
 
     def on_event(ws, event):
@@ -79,9 +83,13 @@ def setup_platform(hass, config, add_entites, discovery_info=None):
             if not event.MAC in entities:
                 new_entity = WyzeSensor(data)
                 entities[event.MAC] = new_entity
+                if entities[event.MAC]._invert_state:
+                    entities[event.MAC]._data[ATTR_STATE] = 1 if entities[event.MAC]._data[ATTR_STATE] == 0 else 0
                 add_entites([new_entity])
             else:
                 entities[event.MAC]._data = data
+                if entities[event.MAC]._invert_state:
+                    entities[event.MAC]._data[ATTR_STATE] = 1 if entities[event.MAC]._data[ATTR_STATE] == 0 else 0
                 entities[event.MAC].schedule_update_ha_state()
 
     @retry(TimeoutError, tries=10, delay=1, logger=_LOGGER)
@@ -98,6 +106,10 @@ def setup_platform(hass, config, add_entites, discovery_info=None):
         _LOGGER.debug("Registering Sensor Entity: %s" % mac)
 
         initial_state = forced_initial_states.get(mac)
+        if mac in invert_states:
+            invert = True
+        else:
+            invert = False
 
         data = {
             ATTR_AVAILABLE: False,
@@ -106,7 +118,7 @@ def setup_platform(hass, config, add_entites, discovery_info=None):
         }
 
         if not mac in entities:
-            new_entity = WyzeSensor(data, should_restore = True, override_restore_state = initial_state)
+            new_entity = WyzeSensor(data, should_restore = True, override_restore_state = initial_state, invert_state = invert)
             entities[mac] = new_entity
             add_entites([new_entity])
 
@@ -151,12 +163,13 @@ def setup_platform(hass, config, add_entites, discovery_info=None):
 class WyzeSensor(BinarySensorDevice, RestoreEntity):
     """Class to hold Hue Sensor basic info."""
 
-    def __init__(self, data, should_restore = False, override_restore_state = None):
+    def __init__(self, data, should_restore = False, override_restore_state = None, invert_state = False):
         """Initialize the sensor object."""
         _LOGGER.debug(data)
         self._data = data 
         self._should_restore = should_restore
         self._override_restore_state = override_restore_state
+        self._invert_state = invert_state
 
     async def async_added_to_hass(self):
         """Run when entity about to be added."""

--- a/custom_components/wyzesense/binary_sensor.py
+++ b/custom_components/wyzesense/binary_sensor.py
@@ -1,6 +1,7 @@
 """ 
 
 wyzesense integration
+v0.0.8
 
 """
 
@@ -14,8 +15,10 @@ from homeassistant.const import CONF_FILENAME, CONF_DEVICE, \
     EVENT_HOMEASSISTANT_STOP, STATE_ON, STATE_OFF, ATTR_BATTERY_LEVEL, \
     ATTR_STATE, ATTR_DEVICE_CLASS, DEVICE_CLASS_TIMESTAMP
 
-from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, \
-    BinarySensorDevice, DEVICE_CLASS_MOTION, DEVICE_CLASS_DOOR
+try:
+    from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensorEntity, DEVICE_CLASS_MOTION, DEVICE_CLASS_DOOR
+except ImportError:
+    from homeassistant.components.binary_sensor import BinarySensorDevice as BinarySensorEntity, PLATFORM_SCHEMA, DEVICE_CLASS_MOTION, DEVICE_CLASS_DOOR
 
 from homeassistant.helpers.restore_state import RestoreEntity
 
@@ -164,7 +167,7 @@ def setup_platform(hass, config, add_entites, discovery_info=None):
     hass.services.register(DOMAIN, SERVICE_REMOVE, on_remove, SERVICE_REMOVE_SCHEMA)
 
 
-class WyzeSensor(BinarySensorDevice, RestoreEntity):
+class WyzeSensor(BinarySensorEntity, RestoreEntity):
     """Class to hold Hue Sensor basic info."""
 
     def __init__(self, data, should_restore = False, override_restore_state = None, invert_state = False):

--- a/custom_components/wyzesense/binary_sensor.py
+++ b/custom_components/wyzesense/binary_sensor.py
@@ -221,7 +221,7 @@ class WyzeSensor(BinarySensorEntity, RestoreEntity):
         return self._data[ATTR_DEVICE_CLASS] if self._data[ATTR_AVAILABLE] else None
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Attributes."""
         attributes = self._data.copy()
         del attributes[ATTR_STATE]

--- a/custom_components/wyzesense/binary_sensor.py
+++ b/custom_components/wyzesense/binary_sensor.py
@@ -88,9 +88,13 @@ def setup_platform(hass, config, add_entites, discovery_info=None):
                 add_entites([new_entity])
             else:
                 entities[event.MAC]._data = data
-                if entities[event.MAC]._invert_state:
-                    entities[event.MAC]._data[ATTR_STATE] = 1 if entities[event.MAC]._data[ATTR_STATE] == 0 else 0
-                entities[event.MAC].schedule_update_ha_state()
+ 
+                try:
+                    if entities[event.MAC]._invert_state:
+                        entities[event.MAC]._data[ATTR_STATE] = 1 if entities[event.MAC]._data[ATTR_STATE] == 0 else 0
+                    entities[event.MAC].schedule_update_ha_state()
+                except (AttributeError, AssertionError):
+                    _LOGGER.debug("wyze Sensor not yet ready for update")
 
     @retry(TimeoutError, tries=10, delay=1, logger=_LOGGER)
     def beginConn():

--- a/custom_components/wyzesense/binary_sensor.py
+++ b/custom_components/wyzesense/binary_sensor.py
@@ -1,7 +1,6 @@
 """ 
 
 wyzesense integration
-v0.0.8
 
 """
 
@@ -60,7 +59,7 @@ def findDongle():
 def setup_platform(hass, config, add_entites, discovery_info=None):
     if config[CONF_DEVICE].lower() == 'auto': 
         config[CONF_DEVICE] = findDongle()
-    _LOGGER.debug("WYZESENSE v0.0.4")
+    _LOGGER.debug("WYZESENSE v0.0.12")
     _LOGGER.debug("Attempting to open connection to hub at " + config[CONF_DEVICE])
 
     forced_initial_states = config[CONF_INITIAL_STATE]

--- a/custom_components/wyzesense/binary_sensor.py
+++ b/custom_components/wyzesense/binary_sensor.py
@@ -12,12 +12,14 @@ import subprocess
 
 from homeassistant.const import CONF_FILENAME, CONF_DEVICE, \
     EVENT_HOMEASSISTANT_STOP, STATE_ON, STATE_OFF, ATTR_BATTERY_LEVEL, \
-    ATTR_STATE, ATTR_DEVICE_CLASS, DEVICE_CLASS_TIMESTAMP
+    ATTR_STATE, ATTR_DEVICE_CLASS
+
+from homeassistant.components.sensor import SensorDeviceClass
 
 try:
-    from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensorEntity, DEVICE_CLASS_MOTION, DEVICE_CLASS_DOOR
+    from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensorEntity, BinarySensorDeviceClass
 except ImportError:
-    from homeassistant.components.binary_sensor import BinarySensorDevice as BinarySensorEntity, PLATFORM_SCHEMA, DEVICE_CLASS_MOTION, DEVICE_CLASS_DOOR
+    from homeassistant.components.binary_sensor import BinarySensorDevice as BinarySensorEntity, PLATFORM_SCHEMA, BinarySensorDeviceClass
 
 from homeassistant.helpers.restore_state import RestoreEntity
 
@@ -74,8 +76,8 @@ def setup_platform(hass, config, add_entites, discovery_info=None):
                 ATTR_AVAILABLE: True,
                 ATTR_MAC: event.MAC,
                 ATTR_STATE: 1 if sensor_state == "open" or sensor_state == "active" else 0,
-                ATTR_DEVICE_CLASS: DEVICE_CLASS_MOTION if sensor_type == "motion" else DEVICE_CLASS_DOOR ,
-                DEVICE_CLASS_TIMESTAMP: event.Timestamp.isoformat(),
+                ATTR_DEVICE_CLASS: BinarySensorDeviceClass.MOTION if sensor_type == "motion" else BinarySensorDeviceClass.DOOR ,
+                SensorDeviceClass.TIMESTAMP: event.Timestamp.isoformat(),
                 ATTR_RSSI: sensor_signal * -1,
                 ATTR_BATTERY_LEVEL: sensor_battery
             }

--- a/custom_components/wyzesense/manifest.json
+++ b/custom_components/wyzesense/manifest.json
@@ -6,5 +6,5 @@
     "dependencies": [],
     "codeowners": ["@jheizer"],
     "homeassistant": "0.92.0",
-    "version":"v0.0.8"
+    "version":"v0.0.10"
 }

--- a/custom_components/wyzesense/manifest.json
+++ b/custom_components/wyzesense/manifest.json
@@ -6,6 +6,6 @@
     "dependencies": [],
     "codeowners": ["@jheizer"],
     "homeassistant": "0.92.0",
-    "version":"v0.0.11"
+    "version":"v0.0.11",
     "iot_class": "local_push"
 }

--- a/custom_components/wyzesense/manifest.json
+++ b/custom_components/wyzesense/manifest.json
@@ -6,5 +6,6 @@
     "dependencies": [],
     "codeowners": ["@jheizer"],
     "homeassistant": "0.92.0",
-    "version":"v0.0.10"
+    "version":"v0.0.11"
+    "iot_class": "local_push"
 }

--- a/custom_components/wyzesense/manifest.json
+++ b/custom_components/wyzesense/manifest.json
@@ -6,6 +6,6 @@
     "dependencies": [],
     "codeowners": ["@jheizer"],
     "homeassistant": "0.92.0",
-    "version":"v0.0.11",
+    "version": "v0.0.11",
     "iot_class": "local_push"
 }

--- a/custom_components/wyzesense/manifest.json
+++ b/custom_components/wyzesense/manifest.json
@@ -1,9 +1,10 @@
 {
     "domain": "wyzesense",
     "name": "Wyze Sense Component",
-    "documentation": "https://github.com/kevinvincent/wyzesense",
+    "documentation": "https://github.com/jheizer/ha-wyzesense",
     "requirements": ["wyzesense==0.0.4","retry==0.9.2"],
     "dependencies": [],
-    "codeowners": ["@kevinvincent"],
-    "homeassistant": "0.92.0"
+    "codeowners": ["@jheizer"],
+    "homeassistant": "0.92.0",
+	"version":"v0.0.8"
 }

--- a/custom_components/wyzesense/manifest.json
+++ b/custom_components/wyzesense/manifest.json
@@ -6,6 +6,6 @@
     "dependencies": [],
     "codeowners": ["@jheizer"],
     "homeassistant": "0.92.0",
-    "version": "v0.0.11",
+    "version": "v0.0.12",
     "iot_class": "local_push"
 }

--- a/custom_components/wyzesense/manifest.json
+++ b/custom_components/wyzesense/manifest.json
@@ -6,5 +6,5 @@
     "dependencies": [],
     "codeowners": ["@jheizer"],
     "homeassistant": "0.92.0",
-	"version":"v0.0.8"
+    "version":"v0.0.8"
 }

--- a/custom_components/wyzesense/manifest.json
+++ b/custom_components/wyzesense/manifest.json
@@ -5,7 +5,6 @@
     "requirements": ["wyzesense==0.0.4","retry==0.9.2"],
     "dependencies": [],
     "codeowners": ["@jheizer"],
-    "homeassistant": "0.92.0",
-    "version": "v0.0.12",
+    "version": "2025.1.0",
     "iot_class": "local_push"
 }

--- a/custom_components/wyzesense/wyzesense_custom.py
+++ b/custom_components/wyzesense/wyzesense_custom.py
@@ -126,10 +126,12 @@ class Packet(object):
             assert len(s) >= 7
             s = s[:7]
             payload = MAKE_CMD(cmd_type, b2)
-        else:
-            assert len(s) >= b2 + 4
+        elif len(s) >= b2 + 4:
             s = s[: b2 + 4]
             payload = s[5:-2]
+        else:
+            log.error("Invalid packet: %s", bytes_to_hex(s))
+            return None
 
         cs_remote = (s[-2] << 8) | s[-1]
         cs_local = checksum_from_bytes(s[:-2])

--- a/custom_components/wyzesense/wyzesense_custom.py
+++ b/custom_components/wyzesense/wyzesense_custom.py
@@ -375,6 +375,8 @@ class Dongle(object):
             except OSError as e:
                 log.error(e)
                 break
+            except:
+                log.exception("Ignoring non-OSError in worker thread. Please share the error logs with the developers.")
 
     def _DoCommand(self, pkt, handler, timeout=_CMD_TIMEOUT):
         e = threading.Event()

--- a/custom_components/wyzesense/wyzesense_custom.py
+++ b/custom_components/wyzesense/wyzesense_custom.py
@@ -253,14 +253,15 @@ class Dongle(object):
         sensor_mac = sensor_mac.decode('ascii')
         alarm_data = pkt.Payload[17:]
         if event_type == 0xA2:
-            if alarm_data[0] == 0x01:
+            if alarm_data[0] == 0x01 or alarm_data[0] == 0x0E:
                 sensor_type = "switch"
                 sensor_state = "open" if alarm_data[5] == 1 else "close"
             elif alarm_data[0] == 0x02:
                 sensor_type = "motion"
                 sensor_state = "active" if alarm_data[5] == 1 else "inactive"
             else:
-                sesor_type = "uknown"
+                log.info("Unknown Sensor Type: %x", alarm_data[0])
+                sensor_type = "unknown"
                 sensor_state = "unknown"
             e = SensorEvent(sensor_mac, timestamp, "state", (sensor_type, sensor_state, alarm_data[2], alarm_data[8]))
         else:

--- a/custom_components/wyzesense/wyzesense_custom.py
+++ b/custom_components/wyzesense/wyzesense_custom.py
@@ -256,7 +256,7 @@ class Dongle(object):
             if alarm_data[0] == 0x01 or alarm_data[0] == 0x0E:
                 sensor_type = "switch"
                 sensor_state = "open" if alarm_data[5] == 1 else "close"
-            elif alarm_data[0] == 0x02:
+            elif alarm_data[0] == 0x02 or alarm_data[0] == 0x0F:
                 sensor_type = "motion"
                 sensor_state = "active" if alarm_data[5] == 1 else "inactive"
             else:


### PR DESCRIPTION
This adds the ability to invert the state of the sensors. I have one stuck in my door bell and it is annoying seeing it as "open". I know if could be changed via templates in the UI, but I think more and more people are going to be using these cheap sensors for unusual tasks to where the feature could be useful and its relatively simple.