### PR TITLE
Ignore non-OSError in Worker thread to keep it alive

### DIFF
--- a/custom_components/wyzesense/wyzesense_custom.py
+++ b/custom_components/wyzesense/wyzesense_custom.py
@@ -372,6 +372,8 @@ class Dongle(object):
             except OSError as e:
                 log.error(e)
                 break
+            except:
+                log.exception("Ignoring non-OSError in worker thread. Please share the error logs with the developers.")
 
     def _DoCommand(self, pkt, handler, timeout=_CMD_TIMEOUT):
         e = threading.Event()


### PR DESCRIPTION
Workaround for #114 
Log the error and ignore it so that the thread is alive
