### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ WARNING: This component does not work on Mac OSX, Synology DSM, or other OSs tha
 0. Have [HACS](https://github.com/custom-components/hacs) installed, this will allow you to easily update
 1. Add `https://github.com/kevinvincent/ha-wyzesense` as a [custom repository](https://custom-components.github.io/hacs/usage/settings/#add-custom-repositories) as Type: Integration
 2. Click install under "Wyze Sense Component", restart your instance.
-3. Plug in the WYZE Sense hub (the usb device) into an open port on your device.
+NOTE: You must have the Wyze Sense Hub removed from you device before installing the Wyze Sense Component and restarting your instance. If not, the setup may fail.
+3. Plug in the Wyze Sense Hub (the usb device) into an open port on your device.
 
 ## Installation (Manual)
 1. Download this repository as a ZIP (green button, top right) and unzip the archive


### PR DESCRIPTION
I had to re-install the wyzesense integration due to an error with HomeKit. Without removing the hub from my Home Assistant device first, the setup would fail over and over. Removing it and following these instructions exactly made the integration install correctly. This note may be helpful for others.
Also changed spelling to match the rest of the document.