### PR TITLE
Add support for the Wyze Sense v2 Door and Motion Sensors

### DIFF
--- a/custom_components/wyzesense/wyzesense_custom.py
+++ b/custom_components/wyzesense/wyzesense_custom.py
@@ -255,14 +255,15 @@ class Dongle(object):
         sensor_mac = sensor_mac.decode('ascii')
         alarm_data = pkt.Payload[17:]
         if event_type == 0xA2:
-            if alarm_data[0] == 0x01:
+            if alarm_data[0] == 0x01 or alarm_data[0] == 0x0E:
                 sensor_type = "switch"
                 sensor_state = "open" if alarm_data[5] == 1 else "close"
             elif alarm_data[0] == 0x02:
                 sensor_type = "motion"
                 sensor_state = "active" if alarm_data[5] == 1 else "inactive"
             else:
-                sesor_type = "uknown"
+                log.info("Unknown Sensor Type: %x", alarm_data[0])
+                sensor_type = "unknown"
                 sensor_state = "unknown"
             e = SensorEvent(sensor_mac, timestamp, "state", (sensor_type, sensor_state, alarm_data[2], alarm_data[8]))
         else:

--- a/custom_components/wyzesense/wyzesense_custom.py
+++ b/custom_components/wyzesense/wyzesense_custom.py
@@ -258,7 +258,7 @@ class Dongle(object):
             if alarm_data[0] == 0x01 or alarm_data[0] == 0x0E:
                 sensor_type = "switch"
                 sensor_state = "open" if alarm_data[5] == 1 else "close"
-            elif alarm_data[0] == 0x02:
+            elif alarm_data[0] == 0x02 or alarm_data[0] == 0x0F:
                 sensor_type = "motion"
                 sensor_state = "active" if alarm_data[5] == 1 else "inactive"
             else:


### PR DESCRIPTION
This commit adds support for both, the Wyze Sense v2 Door sensor and the v2 Motion sensor products.

Yes, both v2 sensors works with the existing USB dongle!

Someone mentioned this in the AMA Reddit thread a few days ago, so I ordered a pack of 3 door sensors, to see if I could get them into the Home Assistant driver.
As you can tell, it is trivial to do.

This driver should now have some new life, as long as we continue to keep our USB dongles.
The fatal MAC/battery issue on the v1's should not be present on the v2's.

