### PR TITLE
'device_state_attributes' is now deprecated

### DIFF
--- a/custom_components/wyzesense/binary_sensor.py
+++ b/custom_components/wyzesense/binary_sensor.py
@@ -238,7 +238,7 @@ class WyzeSensor(BinarySensorEntity, RestoreEntity):
         return self._data[ATTR_DEVICE_CLASS] if self._data[ATTR_AVAILABLE] else None
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Attributes."""
         attributes = self._data.copy()
         del attributes[ATTR_STATE]


### PR DESCRIPTION
'device_state_attributes' is deprecated starting with HA 2021.12.0
replaced 'device_state_attributes' with 'extra_state_attributes'